### PR TITLE
Use module Go versions in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,9 +6,6 @@ on:
       - main
   pull_request:
 
-env:
-  GO_VERSION: stable
-
 permissions:
   contents: read
 
@@ -21,9 +18,6 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
-        with:
-          go-version: ${{ env.GO_VERSION }}
       - id: extract
         run: |
           {
@@ -44,7 +38,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: ${{ matrix.directory }}/go.mod
           cache-dependency-path: ${{ matrix.directory }}
       - name: Run test
         run: |
@@ -64,7 +58,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: ${{ matrix.directory }}/go.mod
           cache-dependency-path: ${{ matrix.directory }}
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
@@ -79,7 +73,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: test/ginkgo/go.mod
           cache-dependency-path: test/ginkgo
       - name: Install ginkgo
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -75,9 +75,6 @@ jobs:
         with:
           go-version-file: test/ginkgo/go.mod
           cache-dependency-path: test/ginkgo
-      - name: Install ginkgo
-        run: |
-          go install github.com/onsi/ginkgo/v2/ginkgo@latest
       - name: Run ginkgo test
         run: |
           go tool ginkgo -p

--- a/.github/workflows/testsum.yaml
+++ b/.github/workflows/testsum.yaml
@@ -20,6 +20,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
+          go-version-file: test/coverage/go.mod
           cache-dependency-path: test/coverage
       - name: Run tests with gotestsum
         run: |


### PR DESCRIPTION
## Summary
- read each module Go version from its go.mod in test and lint jobs
- remove setup-go from the matrix discovery job because it does not run Go commands
- make the coverage summary job read test/coverage/go.mod instead of resolving the implicit stable release

## Validation
- all non-Ginkgo modules: go test ./... --shuffle on --parallel 10 --p 10
- test/ginkgo: go tool ginkgo -p
- parsed all workflow YAML files
- pinact run --check
- zizmor --format plain .